### PR TITLE
Optimize isEmpty

### DIFF
--- a/src/main/scala/parseback/Line.scala
+++ b/src/main/scala/parseback/Line.scala
@@ -27,7 +27,7 @@ final case class Line(base: String, lineNo: Int = 0, colNo: Int = 0) {
 
   def project: String = base substring colNo
 
-  def isEmpty: Boolean = project.length == 0
+  def isEmpty: Boolean = base.length == colNo
 
   def next: Option[Line] =
     if (colNo + 1 < base.length) Some(Line(base, lineNo, colNo + 1)) else None


### PR DESCRIPTION
This avoids the possibility of the array backing the string being copied when using substring, which is something Oracle introduced with JDK7u6.